### PR TITLE
Move ufw setup to separate playbook

### DIFF
--- a/playbooks/debian-basic-absent.yml
+++ b/playbooks/debian-basic-absent.yml
@@ -5,7 +5,7 @@
 
   tasks:
 
-    - name: Install favorite packages
+    - name: Remove some favorite packages for testing
       ansible.builtin.apt:
         state: absent
         pkg: 

--- a/playbooks/debian-basic.yml
+++ b/playbooks/debian-basic.yml
@@ -39,17 +39,6 @@
         - code
       when: inventory_hostname in groups['rpi']
  
-    - name: Enable ufw
-      community.general.ufw:
-        state: enabled
-
-    # Using some port other than the default may add a bit more security
-    # but don't count on obscurity for much
-    - name: Allow SSH through ufw
-      community.general.ufw:
-        rule: allow
-        port: ssh
-
     - name: Display all variables/facts known for a host
       ansible.builtin.debug:
         var: hostvars[inventory_hostname]

--- a/playbooks/linux-setup.yml
+++ b/playbooks/linux-setup.yml
@@ -1,0 +1,3 @@
+---
+- import_playbook: debian-basic.yml
+- import_playbook: ufw.yml

--- a/playbooks/ufw.yml
+++ b/playbooks/ufw.yml
@@ -1,0 +1,17 @@
+---
+- name: Basics for Debian derivatives
+  hosts: all
+  become: yes
+
+  tasks:
+
+    - name: Enable ufw
+      community.general.ufw:
+        state: enabled
+
+    # Using some port other than the default may add a bit more security
+    # but don't count on obscurity for much
+    - name: Allow SSH through ufw
+      community.general.ufw:
+        rule: allow
+        port: ssh


### PR DESCRIPTION
Move ufw setup to separate playbook so it can be quick to enable it on a new machine before any of the other configuration is done.
- Move ufw setup into ufw.yml
- Create linux-setup.yml that imports debian-basic and ufw
- Fix some labels in debian-basic-absent that weren't updated after paste from basic