### PR TITLE
Fix virtual env bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Note: If you have an old version of Python and the following does not find venv,
 
 - `cd ~`
 - `mkdir pyenv`
-- `cd pyenv`
 - `python3 -m venv pyenv/ansible`
 
 ### Ansible


### PR DESCRIPTION
The activate was using a relate path which wouldn't
work if you first change to the pyenv folder. Remove
that command.